### PR TITLE
Adding Manufacturer and direct appointment link.

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -7,7 +7,7 @@ client.login(config.botToken);
 exports.webhookClient = new Discord.WebhookClient(config.webhookID, config.webhookToken);
 exports.embed = (isSuccess,item) => new Discord.MessageEmbed()
     .setTitle(isSuccess ? "Appointment open!" : "Payment declined")
-    .setURL('https://vaccine.heb.com/scheduler')
+    .setURL(item.url)
     .setColor(isSuccess ? "GREEN" : "RED")
     .setDescription(item.name)
    // .setThumbnail(validURL(imageURL) ? imageURL : "")

--- a/webhook.js
+++ b/webhook.js
@@ -16,6 +16,7 @@ exports.embed = (isSuccess,item) => new Discord.MessageEmbed()
         {name: 'Name',value:item.name,inline:true},
         {name: 'Street',value:item.street,inline:true},
         {name: 'City',value:item.city,inline:true},
+        {name: 'Manufacturer',value:item.slotDetails[0].manufacturer,inline:false}
 
     )
     .setTimestamp()


### PR DESCRIPTION
Appointments can be gone pretty quickly after opening up, so I had the embed URL be the direct appointment link that's in the data. Saves a person from inputting their zip/searching for the store before trying to get their appointment. Also, I had it show the vaccine manufacturer since that info is provided too.